### PR TITLE
Add guidance on issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ We use [GitHub](https://github.com/) to collaborate when writing code. We follow
 
 * [Branches](branches.md)
 * [Commits](commits.md)
+* [Issues](issues.md)
 * [Pull requests](pull-requests.md)
 * [Team management](team-management.md)
 

--- a/issues.md
+++ b/issues.md
@@ -20,6 +20,8 @@ An issue is considered ready to be actioned when it has:
 
 These steps are covered in detail in our [team-handbook](https://barnardos.github.io/team-handbook/trello-cards).
 
+Here is [an example of a well written issue](https://github.com/barnardos/design-system/issues/118).
+
 ## Making labels consistent across repos
 
 You should update the labels when creating a new repo.

--- a/issues.md
+++ b/issues.md
@@ -1,0 +1,85 @@
+# Issues
+
+We use [GitHub's issues](https://guides.github.com/features/issues/).
+
+When creating a new issue, you should:
+
+* create it in the appropriate repo
+* apply one of the "type" labels
+* place it into the "Product Team" project
+
+If known at the time, you can also assign the appropriate people to the issue.
+
+## Making labels consistent across repos
+
+You should update the labels when creating a new repo.
+
+1.  Create the following `labels.json` file on your machine:
+
+```json
+[
+  {
+    "name": "estimate: 1",
+    "color": "c5def5"
+  },
+  {
+    "name": "estimate: 2",
+    "color": "c5def5"
+  },
+  {
+    "name": "estimate: 3",
+    "color": "c5def5"
+  },
+  {
+    "name": "estimate: 5",
+    "color": "c5def5"
+  },
+  {
+    "name": "estimate: 8",
+    "color": "c5def5"
+  },
+  {
+    "name": "estimate: 13",
+    "color": "c5def5"
+  },
+  {
+    "name": "status: blocked",
+    "color": "f9d0c4"
+  },
+  {
+    "name": "status: blocker",
+    "color": "d4c5f9"
+  },
+  {
+    "name": "type: bug",
+    "color": "ee0701"
+  },
+  {
+    "name": "type: chore",
+    "color": "5551A8"
+  },
+  {
+    "name": "type: refactor",
+    "color": "1d76db"
+  },
+  {
+    "name": "type: research",
+    "color": "CA2BAF"
+  },
+  {
+    "name": "type: spike",
+    "color": "006b75"
+  },
+  {
+    "name": "type: story",
+    "color": "0e8a16"
+  }
+]
+```
+
+2.  Create a [GitHub access token](https://github.com/settings/tokens).
+3.  Do a dry-run using `npx github-label-sync --access-token xxxxxx --labels labels.json --dry-run barnardos/yyyyyy` but:
+    * replace `xxxxxx` with your access token
+    * replace `yyyyyy` with the repo name
+    * ensure `label.json` points to the file you created
+4.  If the dry-run looks good, run the command again without the `--dry-run` flag.

--- a/issues.md
+++ b/issues.md
@@ -10,6 +10,16 @@ When creating a new issue, you should:
 
 If known at the time, you can also assign the appropriate people to the issue.
 
+## How we write our issues
+
+An issue is considered ready to be actioned when it has:
+
+* a user story / job story
+* acceptance criteria
+* relevant links
+
+These steps are covered in detail in our [team-handbook](https://barnardos.github.io/team-handbook/trello-cards).
+
 ## Making labels consistent across repos
 
 You should update the labels when creating a new repo.


### PR DESCRIPTION
Closes #18 
Closes https://github.com/barnardos/BAU/issues/36

It felt like creating a new repo for this was overkill as:

- the `github-label-sync` tool can be run using `npx`
- any changes to the labels JSON can go through the developer manual review process