### PR TITLE
Adds Short URL details

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,10 @@ To keep deployments consistent we follow:
 
 * [Heroku setup guide](heroku_setup.md)
 
+When we need a unique URL for our project we follow:
+
+* [Short URL setup guide](short_url.md)
+
 ## Tools and methodologies
 
 Within the digital team we use the following:

--- a/short_url.md
+++ b/short_url.md
@@ -1,0 +1,9 @@
+# Creating short URLS
+
+For projects we're working on that are being shared internally or externally we should use a short URL to make it easier for people to access the site.
+
+For internal projects or services (like the live-feed to show and tells, for example) we have been using dr.barnar.do (because that joke works internally and is "cute").
+
+For projects that also are externally facing, e.g. might end up as part of the website, we are using barnar.do/project-name
+
+The login details for the [URL shortener service](http://app.rebrandly.com/) is in the 1Password shared vault.


### PR DESCRIPTION
As a dev team we sometimes need to share URLs with the outside world.

A lot of the URLS we use are ugly and hard to remember, if we want
people to remember the link we've shared we should create a short URL.

This PR adds content provided by @sl33p that was originally found in
[this issue](https://github.com/barnardos/bau/issues/29)

Closes https://github.com/barnardos/bau/issues/29