### PR TITLE
Adds guide for removing developers from tooling

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,10 @@ Within the digital team we use the following:
 * [tools](tools.md)
 * [methodologies](methodologies.md)
 
+## Removing access
+
+When someone leaves the team, [we remove their access to the tools we use](removing_access.md).
+
 ---
 
 If you are not sure how to do any of the things in this manual, please feel free to ask for help. You can change any aspect of this manual through a pull request.

--- a/removing_access.md
+++ b/removing_access.md
@@ -1,0 +1,32 @@
+# Removing access
+
+When someone leaves the team, we remove their access to the tools we use so that:
+
+* they can't pose a security risk
+* they aren't exposed to the risk of seeing something they shouldn't
+* we aren't unnecessarily billed
+
+We do this the day of or the day after someone leaves.
+
+## Steps for removing a developer
+
+For Heroku you should:
+
+1.  visit https://dashboard.heroku.com/teams/barnardos/access
+2.  click the edit icon beside the user to remove
+3.  click "remove user from this team..."
+4.  confirm
+
+For Github you should:
+
+1.  visit https://github.com/orgs/barnardos/people
+2.  click the cog beside the user's name
+3.  select "remove from organisation"
+4.  confirm
+
+For Netlify you should:
+
+1.  visit https://app.netlify.com/teams/barnardo-s-digital/members
+2.  click the ellipses beside the user to remove
+3.  select "remove from team"
+4.  confirm


### PR DESCRIPTION
Explains how we can remove developers from Heroku, Github, and Netlify.