### PR TITLE
Updates standup guidance

### DIFF
--- a/standup.md
+++ b/standup.md
@@ -1,6 +1,6 @@
 # Standup
 
-A standup is a daily meeting to share what we're working on. It provides:
+A standup is a daily text based update to share what we're working on. It provides:
 
 * the opportunity to ask for help – or have it offered
 * enough context to know how best to help those around us
@@ -9,14 +9,10 @@ A standup is a daily meeting to share what we're working on. It provides:
 
 ## The format of a standup
 
-Everyone, in turn, answers the following three questions:
+Everyone answers the following three questions:
 
 * what did you do yesterday?
 * what are you doing today?
 * are there any blockers (something that prevents you doing your work)?
 
-That person then nominates the next person to go.
-
-A standup should last no longer than 15 minutes.
-
-If any member of the team is not present (in the office or via video call) then a standup is done in the [#team_yay](https://barnardos.slack.com/messages/C62V1MEUT) slack channel and follows the same 3 question format.
+The standup is done in the [Product team private room](https://barnardos.facebook.com/chat/t/1730020383726369) on Workplace.


### PR DESCRIPTION
Updates the guidance around standups to reflect what we actually do.

Closes #23 because this was the only reference to Slack in the manual.